### PR TITLE
[minor] patch shallow clone in CI systems dont have tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-publish-release",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "",
   "main": "index.js",
   "bin": {

--- a/src/lib/get-last-tag.ts
+++ b/src/lib/get-last-tag.ts
@@ -2,5 +2,5 @@
 import cmd from './cmd';
 
 export async function getLastTag(): Promise<string> {
-  return await cmd('git describe --tags --abbrev=0');
+  return await cmd('git fetch --prune --unshallow || true; git describe --tags --abbrev=0');
 }


### PR DESCRIPTION
https://stackoverflow.com/questions/4916492/git-describe-fails-with-fatal-no-names-found-cannot-describe-anything/5371322#5371322

got this problem when running `git describe --tags --abbrev=0`, got correct result locally but no name found on ci.

adding the command to fetch full git history.