### PR TITLE
[patch] added command to get the last commit in shallow clone

### DIFF
--- a/src/lib/get-last-tag.ts
+++ b/src/lib/get-last-tag.ts
@@ -2,5 +2,5 @@
 import cmd from './cmd';
 
 export async function getLastTag(): Promise<string> {
-  return await cmd('git fetch --prune --unshallow || true; git describe --tags --abbrev=0');
+  return await cmd('git describe --tags `git rev-list --tags --max-count=1`');
 }


### PR DESCRIPTION
Previously, we added `git fetch` to fetch the history of commits, but this could be slowing down CI a lot because some repos have a long history.

In this PR, this command gets the latest commit tag, which makes shallow clone stay shallow.