### PR TITLE
[patch] fix semver ordering bug

### DIFF
--- a/src/lib/commit-analyzer.ts
+++ b/src/lib/commit-analyzer.ts
@@ -22,8 +22,9 @@ export default async function getVersionType() {
   // find the first item from the commit history matching the release type
   const versionType = find(
     (item) => includes(`[${item}]`, commitHistory),
-    ['major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', 'prerelease', 'dev']
+    ['major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', 'prerelease', 'dev'],
   );
+
   if (!versionType) {
     throw new Error("Can't recognise the release type! Please make sure the repo follows the commit message standard.");
   }

--- a/src/lib/commit-analyzer.ts
+++ b/src/lib/commit-analyzer.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { find, includes } from 'lodash/fp';
 import { getCommitHistory } from './get-commit-history';
 import { getLastTag } from './get-last-tag';
 
@@ -20,9 +20,9 @@ export default async function getVersionType() {
   }
 
   // find the first item from the commit history matching the release type
-  const versionType = _.find(
-    ['dev', 'major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', 'prerelease'],
-    (item) => _.includes(commitHistory, `[${item}]`),
+  const versionType = find(
+    (item) => includes(`[${item}]`, commitHistory),
+    ['major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', 'prerelease', 'dev']
   );
   if (!versionType) {
     throw new Error("Can't recognise the release type! Please make sure the repo follows the commit message standard.");

--- a/test/commit-analyzer.test.ts
+++ b/test/commit-analyzer.test.ts
@@ -1,7 +1,6 @@
-import _ from "lodash";
-import getVersionType from "../src/lib/commit-analyzer";
-import * as getLastTag from "../src/lib/get-last-tag";
-import * as getCommitHistory from "../src/lib/get-commit-history";
+import getVersionType from '../src/lib/commit-analyzer';
+import * as getLastTag from '../src/lib/get-last-tag';
+import * as getCommitHistory from '../src/lib/get-commit-history';
 
 const stubGit = (commitType: string, anotherCommitType: string) => {
   const commitHistory = `44f026c Add eslintrc
@@ -10,45 +9,37 @@ const stubGit = (commitType: string, anotherCommitType: string) => {
       94df78c [${anotherCommitType}]Update README.md
       0f23f08 Update README.md`;
 
-  jest
-    .spyOn(getCommitHistory, "getCommitHistory")
-    .mockResolvedValue(commitHistory);
-  jest.spyOn(getLastTag, "getLastTag").mockResolvedValue("1.2.3");
+  jest.spyOn(getCommitHistory, 'getCommitHistory').mockResolvedValue(commitHistory);
+  jest.spyOn(getLastTag, 'getLastTag').mockResolvedValue('1.2.3');
 };
 
 beforeEach(() => {
   jest.resetAllMocks();
 });
 
-it.each([
-  "major",
-  "minor",
-  "patch",
-  "premajor",
-  "preminor",
-  "prepatch",
-  "prerelease",
-  "dev",
-])("should return %s", async (commitType) => {
-  stubGit(commitType, 'dev');
-  const versionType = await getVersionType();
-  expect(versionType).toEqual(commitType);
-});
+it.each(['major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', 'prerelease', 'dev'])(
+  'should return %s',
+  async (commitType) => {
+    stubGit(commitType, 'dev');
+    const versionType = await getVersionType();
+    expect(versionType).toEqual(commitType);
+  },
+);
 
 it.each([
   {
-    key: "",
     error: new Error(
-      "Can't recognise the release type! Please make sure the repo follows the commit message standard."
+      "Can't recognise the release type! Please make sure the repo follows the commit message standard.",
     ),
+    key: '',
   },
   {
-    key: "other",
     error: new Error(
-      "Can't recognise the release type! Please make sure the repo follows the commit message standard."
+      "Can't recognise the release type! Please make sure the repo follows the commit message standard.",
     ),
+    key: 'other',
   },
-])("should throw an error for $key", async ({ key, error }) => {
+])('should throw an error for $key', async ({ key, error }) => {
   stubGit(key, key);
   const promise = getVersionType();
   await expect(promise).rejects.toThrow(error);

--- a/test/commit-analyzer.test.ts
+++ b/test/commit-analyzer.test.ts
@@ -1,50 +1,55 @@
-import _ from 'lodash';
-import getVersionType from '../src/lib/commit-analyzer';
-import * as getLastTag from '../src/lib/get-last-tag';
-import * as getCommitHistory from '../src/lib/get-commit-history';
+import _ from "lodash";
+import getVersionType from "../src/lib/commit-analyzer";
+import * as getLastTag from "../src/lib/get-last-tag";
+import * as getCommitHistory from "../src/lib/get-commit-history";
 
-const stubGit = (commitType: string) => {
+const stubGit = (commitType: string, anotherCommitType: string) => {
   const commitHistory = `44f026c Add eslintrc
       56c1d28 [${commitType}]: Add some fixes
       83ce07a Extract cmd
-      94df78c [${commitType}]Update README.md
+      94df78c [${anotherCommitType}]Update README.md
       0f23f08 Update README.md`;
 
-  jest.spyOn(getCommitHistory, 'getCommitHistory').mockResolvedValue(commitHistory);
-  jest.spyOn(getLastTag, 'getLastTag').mockResolvedValue('1.2.3');
+  jest
+    .spyOn(getCommitHistory, "getCommitHistory")
+    .mockResolvedValue(commitHistory);
+  jest.spyOn(getLastTag, "getLastTag").mockResolvedValue("1.2.3");
 };
 
 beforeEach(() => {
   jest.resetAllMocks();
 });
 
-_.forOwn(
-  {
-    major: 'major',
-    minor: 'minor',
-    patch: 'patch',
-  },
-  (resultType, commitType) => {
-    it(`should return ${resultType}`, async () => {
-      stubGit(commitType);
-      const versionType = await getVersionType();
-      expect(versionType).toEqual(resultType);
-    });
-  },
-);
+it.each([
+  "major",
+  "minor",
+  "patch",
+  "premajor",
+  "preminor",
+  "prepatch",
+  "prerelease",
+  "dev",
+])("should return %s", async (commitType) => {
+  stubGit(commitType, 'dev');
+  const versionType = await getVersionType();
+  expect(versionType).toEqual(commitType);
+});
 
-_.forOwn(
+it.each([
   {
-    '': new Error("Can't recognise the release type! Please make sure the repo follows the commit message standard."),
-    other: new Error(
-      "Can't recognise the release type! Please make sure the repo follows the commit message standard.",
+    key: "",
+    error: new Error(
+      "Can't recognise the release type! Please make sure the repo follows the commit message standard."
     ),
   },
-  (error, commitType) => {
-    it(`should throw an error for ${commitType}`, async () => {
-      stubGit(commitType);
-      const promise = getVersionType();
-      await expect(promise).rejects.toThrow(error);
-    });
+  {
+    key: "other",
+    error: new Error(
+      "Can't recognise the release type! Please make sure the repo follows the commit message standard."
+    ),
   },
-);
+])("should throw an error for $key", async ({ key, error }) => {
+  stubGit(key, key);
+  const promise = getVersionType();
+  await expect(promise).rejects.toThrow(error);
+});


### PR DESCRIPTION
This repo had a bug where whenever a dev version was introduced into the commit history (such as from renovate), it was ordering dev as higher in the tag order than everything else, so no commits would be published.

This is fixed by moving dev to the back of the list order, so when looking up commits in the history it looks for dev last.

https://medibankdigital.atlassian.net/browse/SF-3377